### PR TITLE
Add edge case - WPScan can't determine vulnerable plugin version

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,10 +15,18 @@ WPSCAN=/usr/local/bundle/bin/wpscan
 $WPSCAN --update
 
 #RESULT=$(cat /example.json)
-RESULT=$($WPSCAN $ARGS)
+RESULT=$($WPSCAN $ARGS -o result.json; cat result.json)
 RESULT_B64=$(echo $RESULT | base64)
 
-echo "result=$RESULT" >> $GITHUB_OUTPUT
-echo "resultb64=$RESULT_B64" >> $GITHUB_OUTPUT
+cat result.json | grep -i limit
+echo "result<<EOF" >> $GITHUB_OUTPUT
+echo "$RESULT" >> $GITHUB_OUTPUT
+echo "EOF" >> $GITHUB_OUTPUT
+
+
+echo "resultb64<<EOF" >> $GITHUB_OUTPUT
+echo "$RESULT_B64" >> $GITHUB_OUTPUT
+echo "EOF" >> $GITHUB_OUTPUT
+
 
 python3 /webhook.py "${RESULT_B64}" "${WEBHOOK}" "${WEBHOOKEVENT}"

--- a/webhook.py
+++ b/webhook.py
@@ -75,9 +75,14 @@ def vulns():
     for p in RESULT['plugins']:
         for v in RESULT['plugins'][p]['vulnerabilities']:
             vuln = parseVuln(v)
+            # Edge case where the WPScan is not able to identify the plugin version
+            if not (RESULT['plugins'][p]['version'] is None):
+                version = f"{RESULT['plugins'][p]['version']['number']} ({RESULT['plugins'][p]['version']['confidence']}%)"
+            else:
+                version = "Unknown"
             vuln['fields'].append({
                         'title': 'Version',
-                        'value': f"{RESULT['plugins'][p]['version']['number']} ({RESULT['plugins'][p]['version']['confidence']}%)",
+                        'value': f"{version}",
                         'short': True
                     })
             attachments.append(vuln)


### PR DESCRIPTION
Proper fix regarding new github output special keyword

Show warning in action log if the API limit has been reached