### PR TITLE
Fix 'error: externally-managed-environment' python installation error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,5 @@ COPY example.json /example.json
 COPY webhook.py /webhook.py
 USER root
 RUN apk add curl python3 py3-pip
-RUN pip3 install requests
+RUN pip3 install requests  --break-system-packages
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
## The issue

When running on the latest ubuntu, we've started encountering this issue where this specific command from Dockerfile fails:
```bash
RUN pip3 install requests
```

After some investigation, there are a few ways to solve this error in Python. [See StackOverflow thread here](https://stackoverflow.com/a/75722775).

A more proper way would be to use a python virtual environment for the libraries, but that seems overkill for a temporary docker container.

Instead I opted for the `--break-system-packages` option which should be fine for the context of a single use docker container.

This seems to have fixed our issue so far.

